### PR TITLE
Minor Updates

### DIFF
--- a/beets.sh
+++ b/beets.sh
@@ -4,7 +4,7 @@ if [ -e .env ]; then
 	export $(xargs < .env)
 fi
 
-PYTHON_VERSION=${PYTHON_VERSION:-3.8.1}
+PYTHON_VERSION=${PYTHON_VERSION:-3.8.16}
 BEETS_VERSION=${BEETS_VERSION:-1.6.0}
 PYLAST_VERSION=${PYLAST_VERSION:-4.4.0}
 BS4_VERSION=${BS4_VERSION:-4.10.0}
@@ -15,10 +15,10 @@ BEETS_COPYARTIFACTS_VERSION=${BEETS_COPYARTIFACTS_VERSION:-0.1.5}
 MUTAGEN_VERSION=${MUTAGEN_VERSION:-1.45.1}
 BEETS_BPMANALYSER_VERSION=${BEETS_BPMANALYSER_VERSION:-1.3.3}
 KEYFINDER_URL=${KEYFINDER_URL:-'https://github.com/mixxxdj/libKeyFinder'}
-KEYFINDER_VERSION=${KEYFINDER_VERSION:-v2.2.6}
+KEYFINDER_VERSION=${KEYFINDER_VERSION:-2.2.7}
 KEYFINDER_LIBRARY_PATH=${KEYFINDER_LIBRARY_PATH:-/usr}
 KEYFINDER_CLI_URL=${KEYFINDER_CLI_URL:-'https://github.com/EvanPurkhiser/keyfinder-cli.git'}
-KEYFINDER_CLI_VERSION=${KEYFINDER_CLI_VERSION:-master}
+KEYFINDER_CLI_VERSION=${KEYFINDER_CLI_VERSION:-main}
 # TODO: Debian 9 doesn't have libcairo 1.15, so update these after updating.
 PYCAIRO_VERSION=${PYCAIRO_VERSION:-1.19.1}
 PYGOBJECT_VERSION=${PYGOBJECT_VERSION:-3.30.5}
@@ -83,8 +83,10 @@ deploy_venv() {
 		xz-utils tk-dev libffi-dev
 
 		if [ $DISABLE_DJ_TOOLS != 'true' ]; then
-			sudo apt-get install --no-install-recommends -y gstreamer1.0 gstreamer1.0-plugins-good \
-			libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+			sudo apt-get install --no-install-recommends -y libgstreamer-plugins-base1.0-dev \
+			gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+			gstreamer1.0-plugins-ugly libgirepository1.0-dev gcc libcairo2-dev pkg-config \
+			python3-dev gir1.2-gtk-3.0 aubio-tools libaubio-dev libaubio-doc
 		fi
 	fi
 
@@ -162,7 +164,7 @@ deploy_keyfinder() {
 	if [[ $PLATFORM == 'Debian' ]]; then
 		sudo apt-get install --no-install-recommends -y \
 			libswresample-dev libavformat-dev libavutil-dev libavcodec-dev \
-			qt5-default qtbase5-dev \
+			qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
 			libfftw3-dev
 	fi
 
@@ -171,7 +173,7 @@ deploy_keyfinder() {
 
 	echo 'Building libKeyFinder'
 	pushd libKeyFinder
-	cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$KEYFINDER_LIBRARY_PATH -S . -B 
+	cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$KEYFINDER_LIBRARY_PATH -S . -B .
 	cmake --build .
 
 	echo 'Installing libKeyFinder'


### PR DESCRIPTION
Another set of minor updates to the Pipeline:

* Changes to the `audit_library` workflow
  * `get_beets_songs` no longer filters to only `flac`. All tracks in the `beets` db will be returned regardless of file extension
  * `get_library_songs` now defaults to both `mp3` and `flac` files being returned. A different collection of extensions can be passed to avoid this
* Updates DJ utility dependencies for Debian 11
  * `aubio` related dependencies to allow for BPM processing of other codecs than WAV
  * `qt5-default` replaced with it's aliased dependencies as the alias no longer exists
* Updates `cmake` build for libKeyFinder to avoid sytax error
* Updates `keyfinder-cli` branch from master -> main
* Updates libKeyFinder from v2.6.6 -> 2.2.7
* Python updated from 3.8.1 -> 3.8.16